### PR TITLE
Don't use Function.prototype.name for naming handlers. Fixes #1

### DIFF
--- a/lib/handler.js
+++ b/lib/handler.js
@@ -5,7 +5,7 @@ Handler = function (path, fn, options) {
     options = options || fn || {};
     fn = path;
     path = '/';
-    
+
     // probably need a better approach here to differentiate between
     // Router.use(function () {}) and Router.use(MyAdminApp). In the first
     // case we don't want to count it as a viable server handler when we're
@@ -46,8 +46,6 @@ Handler = function (path, fn, options) {
     this.name = options.name;
   else if (typeof path === 'string' && path.charAt(0) !== '/')
     this.name = path;
-  else if (fn && fn.name)
-    this.name = fn.name;
   else if (typeof path === 'string' && path !== '/')
     this.name = path.split('/').slice(1).join('.');
 

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'clinical:router-middleware-stack',
   summary: 'Client and server middleware support inspired by Connect.',
-  version: '2.1.1',
+  version: '2.1.2',
   git: 'https://github.com/clinical-meteor/clinical-router-middleware-stack'
 });
 


### PR DESCRIPTION
After the latest Chrome update, iron:router started to present some issues due to routes naming.

This fix this issue based on original iron:router author's fix:
https://github.com/iron-meteor/iron-middleware-stack/commit/7e6da3b1c44cefa91a0a3cf5da419152e653010f
